### PR TITLE
Windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ rancher-ecr-credentials
 .dapper
 
 .idea/*
+dist

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -14,15 +14,18 @@ ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARC
 RUN wget -O - https://storage.googleapis.com/golang/go1.6.2.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
     go get github.com/rancher/trash && go get github.com/golang/lint/golint
 
-ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
-    DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \
-    DOCKER_URL=DOCKER_URL_${ARCH}
+#ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
+#    DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \
+#    DOCKER_URL=DOCKER_URL_${ARCH}
 
-RUN wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker
+#RUN wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker
+
+RUN curl -sfL https://get.docker.com/builds/Linux/x86_64/docker-1.12.6.tgz | tar xzf - -C /usr/bin --strip-components=1; 
 
 ENV DAPPER_SOURCE /go/src/github.com/rancher/rancher-ecr-credentials/
 ENV DAPPER_OUTPUT ./bin ./dist
 ENV DAPPER_DOCKER_SOCKET true
+ENV DAPPER_ENV TAG REPO CROSS WINDOWS_DOCKER_HOST
 ENV TRASH_CACHE ${DAPPER_SOURCE}/.trash-cache
 ENV HOME ${DAPPER_SOURCE}
 WORKDIR ${DAPPER_SOURCE}

--- a/package/windows/amd64/Dockerfile
+++ b/package/windows/amd64/Dockerfile
@@ -1,0 +1,3 @@
+FROM microsoft/nanoserver:10.0.14393.1593
+COPY rancher-ecr-credentials.exe  /
+CMD /rancher-ecr-credentials.exe

--- a/scripts/build
+++ b/scripts/build
@@ -5,6 +5,29 @@ source $(dirname $0)/version
 
 cd $(dirname $0)/..
 
+rm -rf bin/*
+
 mkdir -p bin
 [ "$(uname)" != "Darwin" ] && LINKFLAGS="-linkmode external -extldflags -static -s"
 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/rancher-ecr-credentials
+
+declare -A OS_ARCH_ARG
+
+OS_PLATFORM_ARG=(linux windows)
+OS_ARCH_ARG[linux]="amd64"
+OS_ARCH_ARG[windows]="amd64"
+
+if [ -n "$CROSS" ]; then
+    for OS in ${OS_PLATFORM_ARG[@]}; do
+        for ARCH in ${OS_ARCH_ARG[${OS}]}; do
+            OUTPUT_BIN="bin/$OS/$ARCH/rancher-ecr-credentials"
+            if test "$OS" = "windows"; then
+                OUTPUT_BIN="${OUTPUT_BIN}.exe"
+            fi
+            echo "Building binary for $OS/$ARCH..."
+            GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 go build \
+                  -ldflags="-X main.VERSION=$VERSION" \
+                  -o ${OUTPUT_BIN} ./
+        done
+    done
+fi

--- a/scripts/package
+++ b/scripts/package
@@ -5,6 +5,7 @@ source $(dirname $0)/version
 
 ARCH=${ARCH:?"ARCH not set"}
 SUFFIX=""
+SCRIPTPATH="$(cd "$(dirname "$0")"; pwd -P)"
 [ "${ARCH}" != "amd64" ] && SUFFIX="_${ARCH}"
 
 cd $(dirname $0)/../package
@@ -16,5 +17,47 @@ cp ../bin/rancher-ecr-credentials .
 
 IMAGE=${REPO}/rancher-ecr-credentials:${TAG}
 docker build -t ${IMAGE} .
+mkdir -p dist && rm -rf dist/*
 echo ${IMAGE} > ../dist/images
 echo Built ${IMAGE}
+
+package() {
+  local os arch suffix tag repo env image_name binary_name
+  os=$1
+  arch=$2
+  image_name="rancher-ecr-credentials"
+  binary_name="rancher-ecr-credentials"
+  if [ "$WINDOWS_DOCKER_HOST" == "" -a "$os" == "windows" ]; then
+      echo "WINDOWS_DOCKER_HOST is not set, skip packaging Windows image"
+      return
+  fi
+  [ "$os"   == "windows" ] && binary_name="${binary_name}.exe"
+  [ "$os"   != "linux" ] && image_name="${image_name}-${os}"
+  [ "$arch" != "amd64" ] && suffix="${suffix}_${arch}"
+  
+  tag="${TAG:-${VERSION}${SUFFIX}}"
+
+  if [ ! -d "package/$os/$arch" ]; then 
+      echo "Directory package/$os/$arch not exist, skip package"
+      return
+  fi
+  cp bin/$os/$arch/$binary_name package/$os/$arch
+
+  # because if building windows image, need to connect to docker on windows. set DOCKER_HOST for docker build context
+  [ "$os" == "windows" ] && dhost="tcp://$WINDOWS_DOCKER_HOST:2375" || dhost="$DOCKER_HOST"
+  DOCKER_HOST=$dhost docker build -t ${REPO}/${image_name}:${tag} -f package/$os/$arch/Dockerfile package/$os/$arch
+
+  echo ${REPO}/${image_name}:${tag} >> dist/images
+  echo Built ${REPO}/${image_name}:${tag}
+}
+
+source $SCRIPTPATH/version
+cd $SCRIPTPATH/..
+
+if [ -n "$CROSS" ]; then
+    for os in $(ls bin); do
+        for arch in $(ls bin/$os); do
+            package $os $arch
+        done
+    done
+fi


### PR DESCRIPTION
Related issue rancher/rancher#12018
1. Add Windows image dockerfile
2. Modify build and package scripts to support cross build
3. Update Dockerfile.dapper to use Docker 1.12.6 instead of 1.10.3
4. Update Dockerfile.dapper to pass CROSS and WINDOWS_DOCKER_HOST environment vairable into it.
5. Update .gitignore to ignore dist folder

You can build the Rancher ECR with `TAG=<tag> CROSS=1 WINDOWS_DOCKER_HOST=<windows host> make`.